### PR TITLE
Fixed for null titles failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,14 @@
 node_modules
 .DS_Store
 sqlite
+.vscode
 
-sqlite/sec_data.db
 .env
 src/htmlLayouts/index.html
 
 images
 dist
-
+secrets
 .twitter.tokens.json
 .bluesky.tokens.json
 launchd.err.log

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,9 @@ import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
+  {
+    ignores: ['dist/**'],
+  },
   eslint.configs.recommended,
   tseslint.configs.recommended,
   [

--- a/src/processing/formatClusterOutput.ts
+++ b/src/processing/formatClusterOutput.ts
@@ -53,6 +53,16 @@ const compactFormat = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 2
 });
 
+function normalizeTitles(titles: string | null | undefined): string[] {
+  if (!titles) return [];
+  return [...new Set(
+    titles
+      .split('**')
+      .map((item) => item.trim())
+      .filter(Boolean)
+  )];
+}
+
 /**
  * Converter of raw sales data into info that can be converted to html
  * @param {Array<RawSalesOutput>} sales Array of sales data
@@ -97,7 +107,8 @@ export function formatSalesOutput(sales: RawSalesOutput[]): FormatOutput[] {
 
     const context = `The weighted average sale price was ${sharePriceFormat}/share - ${movingAvgPctAbove()} the 200-day MA.`;
 
-    const titlesFormat = [...new Set(titles.split('**').map(item => item.trim()))].join(' / ');
+    const titlesArray = normalizeTitles(titles);
+    const titlesFormat = titlesArray.length ? titlesArray.join(' / ') : 'UNNAMED INSIDERS';
 
     const aggregatedOutput: HtmlStringData = {
       companyName: company_name,
@@ -181,9 +192,9 @@ export function formatPurchaseOutput(purchases: RawPurchaseOutput[]): FormatOutp
 
     const priceAverage = `The weighted average purchase price was ${sharePriceFormat}/share - ${m20} and ${m200}`;
 
-    const titlesArray = [...new Set(titles.split('**').map(item => item.trim()))];
+    const titlesArray = normalizeTitles(titles);
     const nullAdditions = num_null_titles > 0 ? `${num_null_titles} UNNAMED INSIDERS` : '';
-    const titlesFormat = [...titlesArray, nullAdditions].join(' / ');
+    const titlesFormat = [...titlesArray, nullAdditions].filter(Boolean).join(' / ') || 'UNNAMED INSIDERS';
 
     const aggregatedOutput: HtmlStringData = {
       companyName: company_name,
@@ -442,5 +453,4 @@ function createHtmlString(documentInfo: HtmlStringData, isPurchase: boolean = fa
 
   return htmlFrame;
 }
-
 

--- a/src/removeExpiredImages.ts
+++ b/src/removeExpiredImages.ts
@@ -17,14 +17,14 @@ export async function removeExpiredImages(db: any) {
     try {
       await rm(twitterPath);
       console.info(`Deleted Twitter image:${cluster_id}`);
-    } catch (err) {
+    } catch {
       console.warn('Error deleting image:', twitterPath);
     }
 
     try {
       await rm(blueskyPath);
       console.info(`Deleted Bluesky image:${cluster_id}`);
-    } catch (err) {
+    } catch {
       console.warn('Error deleting image:', blueskyPath);
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,7 +171,7 @@ export type RawSalesOutput = {
   all_are_officers: number,
   mixed_officer_dir: number,
   owners: string;
-  titles: string;
+  titles: string | null;
   ma200: number,
   off_ma200: number; // negative number
 };
@@ -194,7 +194,7 @@ export type RawPurchaseOutput = {
   all_are_directors: number,
   all_are_officers: number,
   owners: string,
-  titles: string,
+  titles: string | null,
   off_ma20: number,
   off_ma200: number,
 };


### PR DESCRIPTION
Logs showed failure if all titles are null. Fix for this was applied
```log
file:///app/dist/processing/formatClusterOutput.js:130
        const titlesArray = [...new Set(titles.split('**').map(item => item.trim()))];
                                               ^

TypeError: Cannot read properties of null (reading 'split')
    at formatPurchaseOutput (file:///app/dist/processing/formatClusterOutput.js:130:48)
    at runOrchestrator (file:///app/dist/index.js:89:33)

```